### PR TITLE
Fix duplicate developer page exception filter

### DIFF
--- a/src/SneakPeek/Program.cs
+++ b/src/SneakPeek/Program.cs
@@ -20,11 +20,6 @@ builder.Services.AddDbContext<DataContext>(opt => opt.UseInMemoryDatabase("Movie
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 var app = builder.Build();
 
-if (builder.Environment.IsDevelopment())
-{
-    builder.Services.AddDatabaseDeveloperPageExceptionFilter();
-}
-
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
## Summary
- remove the duplicate `AddDatabaseDeveloperPageExceptionFilter` call after `Build`
- ensure service registration happens before `Build`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684906c589b483228eff26505e28506e