### PR TITLE
Fix comment spacing in MoviesControllerTests

### DIFF
--- a/tests/SneakPeak.IntegrationTests/MoviesControllerTests.cs
+++ b/tests/SneakPeak.IntegrationTests/MoviesControllerTests.cs
@@ -16,14 +16,14 @@ public class MoviesControllerTests : IClassFixture<WebApplicationFactory<Program
     [Fact]
     public async Task Get_MoviesEndpointsReturnSuccessAndCorrectContentType()
     {
-        //Arrange
+        // Arrange
         const string url = "/movies";
         var client = _factory.CreateClient();
 
-        //Act
+        // Act
         var response = await client.GetAsync(url);
 
-        //Assert
+        // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.ToString().Should().Be("text/json; charset=utf-8");
     }


### PR DESCRIPTION
## Summary
- tidy up comment spacing in MoviesControllerTests

## Testing
- `dotnet test` *(fails: 4 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684906c7259c8322ad64ed5467020097