### PR TITLE
SPK-14: Replace InMemory database with SQLite implementation

### DIFF
--- a/src/SneakPeek/Program.cs
+++ b/src/SneakPeek/Program.cs
@@ -19,7 +19,7 @@ builder.Services.AddHttpClient("MyHttpClient", client =>
 });
 
 builder.Services.AddControllers();
-builder.Services.AddDbContext<DataContext>(opt => opt.UseInMemoryDatabase("Movies"));
+builder.Services.AddDbContext<DataContext>(opt => opt.UseSqlite("Data Source=SneakPeek.db"));
 
 builder.Services.AddScoped<IMoviesRepository, MoviesRepository>();
 


### PR DESCRIPTION
## Summary
- Replace InMemory database configuration with SQLite in Program.cs
- Configure SQLite to use "SneakPeek.db" database file  
- Complete SPK-14 acceptance criteria for persistent database storage

## Changes Made
- Updated `DataContext` registration from `UseInMemoryDatabase("Movies")` to `UseSqlite("Data Source=SneakPeek.db")`
- Application now uses persistent SQLite database instead of temporary in-memory storage

## Test Plan
- [x] Build succeeds with no errors
- [x] SQLite packages already installed in Persistence project
- [x] DataContext properly configured with Movie DbSet
- [x] Repository pattern ready to work with persistent storage

## Related Issues
Closes SPK-14